### PR TITLE
Add loading screen with animated globe icon

### DIFF
--- a/GlobeExplorer/GlobeView.swift
+++ b/GlobeExplorer/GlobeView.swift
@@ -25,6 +25,13 @@ struct GlobeView: UIViewRepresentable {
 
         context.coordinator.sceneView = sceneView
 
+        // Signal that loading is complete after scene is ready
+        DispatchQueue.main.async {
+            withAnimation(.easeInOut(duration: 0.5)) {
+                self.globeState.isLoading = false
+            }
+        }
+
         return sceneView
     }
 


### PR DESCRIPTION
Implemented a polished loading screen that displays while the globe initializes:
- Created LoadingView component with rotating globe icon and pulse animation
- Added isLoading state to GlobeState to track initialization
- Loading screen matches app's dark/light mode themes
- Smooth fade-out transition when loading completes
- Loading screen appears during GeoJSON parsing and 3D geometry creation