### PR TITLE
fix: prevent South Africa overlay from covering Lesotho enclave

### DIFF
--- a/GlobeCacheGenerator/main.swift
+++ b/GlobeCacheGenerator/main.swift
@@ -6,6 +6,7 @@ import SceneKit
 struct GeoJSONCountry {
     let name: String
     let polygons: [[[Double]]]
+    let holes: [[[Double]]]
     let isPointCountry: Bool
     let pointCoordinate: (lat: Double, lon: Double)?
 
@@ -43,6 +44,7 @@ func loadCountries(from geojsonPath: String) -> [GeoJSONCountry] {
                 let country = GeoJSONCountry(
                     name: name,
                     polygons: [],
+                    holes: [],
                     isPointCountry: true,
                     pointCoordinate: (lat: lat, lon: lon)
                 )
@@ -50,11 +52,16 @@ func loadCountries(from geojsonPath: String) -> [GeoJSONCountry] {
             }
         } else {
             var polygons: [[[Double]]] = []
+            var holes: [[[Double]]] = []
 
             if type == "Polygon" {
                 if let coords = coordinates as? [[[Double]]] {
+                    // First ring is the outer boundary; subsequent rings are holes (e.g., enclaves)
                     if let outerRing = coords.first {
                         polygons.append(outerRing)
+                    }
+                    if coords.count > 1 {
+                        holes.append(contentsOf: coords.dropFirst())
                     }
                 }
             } else if type == "MultiPolygon" {
@@ -62,6 +69,9 @@ func loadCountries(from geojsonPath: String) -> [GeoJSONCountry] {
                     for polygon in multiCoords {
                         if let outerRing = polygon.first {
                             polygons.append(outerRing)
+                        }
+                        if polygon.count > 1 {
+                            holes.append(contentsOf: polygon.dropFirst())
                         }
                     }
                 }
@@ -71,6 +81,7 @@ func loadCountries(from geojsonPath: String) -> [GeoJSONCountry] {
                 let country = GeoJSONCountry(
                     name: name,
                     polygons: polygons,
+                    holes: holes,
                     isPointCountry: isPointCountry,
                     pointCoordinate: nil
                 )
@@ -158,7 +169,7 @@ func createGlobeNode(countries: [GeoJSONCountry]) -> SCNNode {
             globeNode.addChildNode(outlineNode)
             globeNode.addChildNode(node)
         } else {
-            if let geometry = PolygonTriangulator.createCountryGeometry(polygons: country.polygons) {
+            if let geometry = PolygonTriangulator.createCountryGeometry(polygons: country.polygons, holes: country.holes) {
                 let material = SCNMaterial()
                 material.diffuse.contents = landColor
                 material.specular.contents = NSColor.clear

--- a/voyage/DailyChallenge/CountrySilhouetteView.swift
+++ b/voyage/DailyChallenge/CountrySilhouetteView.swift
@@ -35,6 +35,10 @@ struct CountrySilhouetteView: View {
 
                 let fillColor = isDarkMode ? Color.white : Color(red: 0.2, green: 0.15, blue: 0.1)
 
+                // Build one combined path with outer rings and hole rings.
+                // Even-odd fill punches out enclave holes (e.g., Lesotho in South Africa).
+                var combinedPath = Path()
+
                 for polygon in country.polygons {
                     guard polygon.count >= 3 else { continue }
                     var path = Path()
@@ -49,8 +53,27 @@ struct CountrySilhouetteView: View {
                         }
                     }
                     path.closeSubpath()
-                    context.fill(path, with: .color(fillColor))
+                    combinedPath.addPath(path)
                 }
+
+                for hole in country.holes {
+                    guard hole.count >= 3 else { continue }
+                    var path = Path()
+                    for (i, coord) in hole.enumerated() {
+                        guard coord.count >= 2 else { continue }
+                        let x = (coord[0] - minLon) * scale + offsetX
+                        let y = (maxLat - coord[1]) * scale + offsetY
+                        if i == 0 {
+                            path.move(to: CGPoint(x: x, y: y))
+                        } else {
+                            path.addLine(to: CGPoint(x: x, y: y))
+                        }
+                    }
+                    path.closeSubpath()
+                    combinedPath.addPath(path)
+                }
+
+                context.fill(combinedPath, with: .color(fillColor), style: FillStyle(eoFill: true))
             }
         } else {
             Image(systemName: "questionmark.square.dashed")

--- a/voyage/GeoJSONParser.swift
+++ b/voyage/GeoJSONParser.swift
@@ -3,7 +3,8 @@ import UIKit
 
 struct GeoJSONCountry {
     let name: String
-    let polygons: [[[Double]]] // Array of polygons, each polygon is array of [lon, lat] coordinates (empty for point countries)
+    let polygons: [[[Double]]] // Array of outer rings, each ring is array of [lon, lat] coordinates (empty for point countries)
+    let holes: [[[Double]]]    // Inner rings (holes) — e.g., the Lesotho enclave inside South Africa
     let color: UIColor
     let continent: String?
     let isPointCountry: Bool
@@ -59,6 +60,7 @@ class GeoJSONParser {
                     let country = GeoJSONCountry(
                         name: name,
                         polygons: [],
+                        holes: [],
                         color: GeoJSONCountry.landColor(),
                         continent: continent,
                         isPointCountry: true,
@@ -71,12 +73,16 @@ class GeoJSONParser {
             } else {
                 // Polygon or MultiPolygon country
                 var polygons: [[[Double]]] = []
+                var holes: [[[Double]]] = []
 
                 if type == "Polygon" {
                     if let coords = coordinates as? [[[Double]]] {
-                        // Take only the outer ring (first element)
+                        // First ring is the outer boundary; subsequent rings are holes (e.g., enclaves)
                         if let outerRing = coords.first {
                             polygons.append(outerRing)
+                        }
+                        if coords.count > 1 {
+                            holes.append(contentsOf: coords.dropFirst())
                         }
                     }
                 } else if type == "MultiPolygon" {
@@ -84,6 +90,9 @@ class GeoJSONParser {
                         for polygon in multiCoords {
                             if let outerRing = polygon.first {
                                 polygons.append(outerRing)
+                            }
+                            if polygon.count > 1 {
+                                holes.append(contentsOf: polygon.dropFirst())
                             }
                         }
                     }
@@ -93,6 +102,7 @@ class GeoJSONParser {
                     let country = GeoJSONCountry(
                         name: name,
                         polygons: polygons,
+                        holes: holes,
                         color: GeoJSONCountry.landColor(),
                         continent: continent,
                         isPointCountry: isPointCountry,

--- a/voyage/GlobeScene.swift
+++ b/voyage/GlobeScene.swift
@@ -16,6 +16,10 @@ class GlobeScene {
             // Rebuild the countryNodes and originalColors dictionaries from cached nodes
             rebuildCoordinatorData(from: bundledGlobe, coordinator: coordinator)
 
+            // Patch any countries whose cached geometry was built without hole support
+            // (e.g., South Africa's fill incorrectly covered the Lesotho enclave)
+            patchHoleCountries(in: bundledGlobe)
+
             // Start facing Europe/Africa (~15°E longitude)
             bundledGlobe.eulerAngles.y = -.pi / 2 - .pi / 12
 
@@ -105,6 +109,22 @@ class GlobeScene {
         return globeNode
     }
 
+    /// Replace fill geometry for countries whose cached .scn was built without hole support.
+    private static func patchHoleCountries(in globeNode: SCNNode) {
+        for country in CountryDataCache.shared.countries where !country.holes.isEmpty {
+            guard let node = globeNode.childNode(withName: country.name, recursively: true) else { continue }
+            if let newGeometry = PolygonTriangulator.createCountryGeometry(
+                polygons: country.polygons,
+                holes: country.holes
+            ) {
+                if let existingMaterials = node.geometry?.materials {
+                    newGeometry.materials = existingMaterials
+                }
+                node.geometry = newGeometry
+            }
+        }
+    }
+
     private static func rebuildCoordinatorData(from globeNode: SCNNode, coordinator: GlobeView.Coordinator) {
         let landColor = AppColors.landUI
 
@@ -171,7 +191,7 @@ class GlobeScene {
                 coordinator.originalColors[country.name] = landColor
             } else {
                 // Render as polygon (regular countries)
-                if let geometry = PolygonTriangulator.createCountryGeometry(polygons: country.polygons) {
+                if let geometry = PolygonTriangulator.createCountryGeometry(polygons: country.polygons, holes: country.holes) {
                     let material = SCNMaterial()
                     material.diffuse.contents = country.color
                     material.specular.contents = UIColor.clear

--- a/voyage/MapView.swift
+++ b/voyage/MapView.swift
@@ -123,18 +123,21 @@ struct MapView: View {
                             else { fillShading = hasTexture ? .color(.clear) : .color(AppColors.land) }
                         }
 
-                        // Draw all polygons with the determined shading
+                        // Draw all polygons with the determined shading.
+                        // Outer rings and hole rings are combined into one path; using the
+                        // even-odd fill rule punches out holes (e.g., Lesotho inside South Africa).
+                        var outerPaths: [Path] = []
+                        var combinedFillPath = Path()
+
                         for polygon in country.polygons {
                             var path = Path()
                             var firstPoint = true
-
                             for coord in polygon {
                                 guard coord.count >= 2 else { continue }
                                 let point = CGPoint(
                                     x: (coord[0] + 180) / 360 * mapWidth,
                                     y: (90 - coord[1]) / 180 * mapHeight + verticalOffset
                                 ).applying(transform)
-
                                 if firstPoint {
                                     path.move(to: point)
                                     firstPoint = false
@@ -143,8 +146,35 @@ struct MapView: View {
                                 }
                             }
                             path.closeSubpath()
+                            outerPaths.append(path)
+                            combinedFillPath.addPath(path)
+                        }
 
-                            context.fill(path, with: fillShading)
+                        for hole in country.holes {
+                            var path = Path()
+                            var firstPoint = true
+                            for coord in hole {
+                                guard coord.count >= 2 else { continue }
+                                let point = CGPoint(
+                                    x: (coord[0] + 180) / 360 * mapWidth,
+                                    y: (90 - coord[1]) / 180 * mapHeight + verticalOffset
+                                ).applying(transform)
+                                if firstPoint {
+                                    path.move(to: point)
+                                    firstPoint = false
+                                } else {
+                                    path.addLine(to: point)
+                                }
+                            }
+                            path.closeSubpath()
+                            combinedFillPath.addPath(path)
+                        }
+
+                        // Even-odd fill: hole sub-paths toggle the winding count, leaving
+                        // enclave areas (Lesotho) transparent so the underlying country shows through.
+                        context.fill(combinedFillPath, with: fillShading, style: FillStyle(eoFill: true))
+                        // Only stroke outer country borders; enclave borders belong to the enclave country.
+                        for path in outerPaths {
                             context.stroke(path, with: borderShading, lineWidth: borderWidth)
                         }
                     }

--- a/voyage/PolygonTriangulator.swift
+++ b/voyage/PolygonTriangulator.swift
@@ -44,7 +44,8 @@ class PolygonTriangulator {
 
     // Create country fill geometry using adaptive grid-based point-in-polygon fill.
     // Large cells cover the interior; cells near borders subdivide to finer resolution.
-    static func createCountryGeometry(polygons: [[[Double]]], radius: Float = 1.003) -> SCNGeometry? {
+    // holes: inner ring coordinates to exclude from the fill (e.g., the Lesotho enclave in South Africa).
+    static func createCountryGeometry(polygons: [[[Double]]], holes: [[[Double]]] = [], radius: Float = 1.003) -> SCNGeometry? {
         var allVertices: [SCNVector3] = []
         var allIndices: [Int32] = []
 
@@ -106,10 +107,16 @@ class PolygonTriangulator {
             }
 
             func addCell(lat: Double, lon: Double, size: Double) {
-                let centerIn = isPointInPolygon(lon: lon + size / 2, lat: lat + size / 2, polygon: coords)
+                let centerLon = lon + size / 2
+                let centerLat = lat + size / 2
+                let centerIn = isPointInPolygon(lon: centerLon, lat: centerLat, polygon: coords)
 
                 if size <= minSize {
-                    if centerIn { emitCell(lat: lat, lon: lon, size: size) }
+                    if centerIn {
+                        // Exclude cells whose center falls inside a hole (e.g., Lesotho within South Africa)
+                        let inHole = holes.contains { isPointInPolygon(lon: centerLon, lat: centerLat, polygon: $0) }
+                        if !inHole { emitCell(lat: lat, lon: lon, size: size) }
+                    }
                     return
                 }
 
@@ -126,7 +133,24 @@ class PolygonTriangulator {
                                   isPointInPolygon(lon: lon + half, lat: lat + size, polygon: coords) &&
                                   isPointInPolygon(lon: lon, lat: lat + half, polygon: coords)
                     if edgesIn {
-                        emitCell(lat: lat, lon: lon, size: size)
+                        // Before emitting, check whether a hole overlaps this cell.
+                        // A hole overlaps if its center lands inside, or any hole vertex is within the cell bounds.
+                        let holeOverlaps = !holes.isEmpty && holes.contains { hole in
+                            isPointInPolygon(lon: centerLon, lat: centerLat, polygon: hole) ||
+                            hole.contains { coord in
+                                coord[0] >= lon && coord[0] <= lon + size &&
+                                coord[1] >= lat && coord[1] <= lat + size
+                            }
+                        }
+                        if holeOverlaps {
+                            // Subdivide so the hole boundary is respected at finer resolution
+                            addCell(lat: lat, lon: lon, size: half)
+                            addCell(lat: lat, lon: lon + half, size: half)
+                            addCell(lat: lat + half, lon: lon, size: half)
+                            addCell(lat: lat + half, lon: lon + half, size: half)
+                        } else {
+                            emitCell(lat: lat, lon: lon, size: size)
+                        }
                     } else {
                         // Edge crosses concavity — subdivide
                         addCell(lat: lat, lon: lon, size: half)


### PR DESCRIPTION
South Africa's GeoJSON polygon has an inner ring (hole) representing the
Lesotho enclave. The parser was discarding all inner rings, causing South
Africa's fill geometry to incorrectly cover Lesotho on both the globe and
map views.

Changes:
- GeoJSONParser: add `holes` field to GeoJSONCountry; collect inner rings
  for Polygon and MultiPolygon types instead of silently dropping them
- PolygonTriangulator: add `holes` param to createCountryGeometry; skip
  grid cells whose centre falls inside a hole, and force subdivision when
  a hole boundary crosses an otherwise fully-interior cell
- GlobeScene: call patchHoleCountries() after loading the pre-built
  globe.scn cache to regenerate South Africa's fill geometry with the
  Lesotho hole excluded; pass holes through the scratch-build code path
- MapView: build a combined path (outer rings + hole rings) per country
  and fill with FillStyle(eoFill: true) so enclave areas are transparent;
  stroke only outer borders to avoid double-drawing enclave boundaries
- CountrySilhouetteView: same even-odd fix so the daily challenge
  silhouette for South Africa correctly shows the Lesotho cutout
- GlobeCacheGenerator: mirror the parser and geometry changes so future
  cache regenerations produce correct hole-aware geometry

https://claude.ai/code/session_01MxFqiTGPH9xNfGCB5VyfY2